### PR TITLE
채팅방 목록 가져오는 API 예외 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 	implementation 'org.webjars:stomp-websocket:2.3.4'
 	// gson
 	implementation 'com.google.code.gson:gson:2.9.0'
+	// valid
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
+
 
 	implementation 'junit:junit:4.13.1'
 	implementation 'junit:junit:4.13.1'

--- a/src/main/java/com/mate/helgather/controller/ChatRoomController.java
+++ b/src/main/java/com/mate/helgather/controller/ChatRoomController.java
@@ -1,15 +1,20 @@
 package com.mate.helgather.controller;
 
 import com.mate.helgather.dto.ChatRoomListResponse;
+import com.mate.helgather.exception.BaseResponse;
 import com.mate.helgather.service.ChatRoomService;
 import com.mate.helgather.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.Valid;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,8 +30,8 @@ public class ChatRoomController {
      * @return List<ChatRoomListResponse> 채팅방들의 원하는 정보를 리스트로 반환
      */
     @GetMapping("/members/{id}/chatrooms")
-    public List<ChatRoomListResponse> getChatRoomsByMemberIdV2(@PathVariable Long id) {
-        return chatRoomService.getChatRoomsByMemberId(id);
+    public ResponseEntity<BaseResponse> getChatRoomsByMemberIdV2(@PathVariable @Valid Long id) throws Exception {
+        List<ChatRoomListResponse> chatRoomsByMemberId = chatRoomService.getChatRoomsByMemberId(id);
+        return new ResponseEntity<>(new BaseResponse(200, "성공입니다.", chatRoomsByMemberId), HttpStatus.OK);
     }
-
 }

--- a/src/main/java/com/mate/helgather/dto/ChatRoomListResponse.java
+++ b/src/main/java/com/mate/helgather/dto/ChatRoomListResponse.java
@@ -4,15 +4,11 @@ import lombok.Getter;
 
 @Getter
 public class ChatRoomListResponse {
-    // 상대 유저 아이디
-    String id;
+    String id; // 상대 유저 아이디
     String time;
-    // 유저 프로필 사진
-    int profile;
-    // 프리뷰
-    String preview;
-    // 채팅방 id
-    Long chatId;
+    int profile; // 유저 프로필 사진
+    String preview; // 프리뷰
+    Long chatId; // 채팅방 id
 
     public ChatRoomListResponse(String id, String time, String preview, Long chatId) {
         this.id = id;

--- a/src/main/java/com/mate/helgather/exception/BaseResponse.java
+++ b/src/main/java/com/mate/helgather/exception/BaseResponse.java
@@ -1,0 +1,37 @@
+package com.mate.helgather.exception;
+
+import com.fasterxml.jackson.databind.ser.Serializers;
+import lombok.Getter;
+
+@Getter
+public class BaseResponse {
+
+    private boolean isSuccess;
+    private int code;
+
+    private String message;
+    private Object result;
+
+    // 실패했을 때
+    public BaseResponse(int code, String message) {
+        this.isSuccess = false;
+        this.code = code;
+        this.message = message;
+    }
+
+    // 성공했을 때
+    public BaseResponse(int code, String message, Object result) {
+        this.isSuccess = true;
+        this.code = code;
+        this.message = message;
+        this.result = result;
+    }
+
+    //
+    public BaseResponse(boolean isSuccess, int code, String message, Object result) {
+        this.isSuccess = isSuccess;
+        this.code = code;
+        this.message = message;
+        this.result = result;
+    }
+}

--- a/src/main/java/com/mate/helgather/exception/ErrorCode.java
+++ b/src/main/java/com/mate/helgather/exception/ErrorCode.java
@@ -1,4 +1,5 @@
 package com.mate.helgather.exception;
 
 public enum ErrorCode {
+    NO_SUCH_MEMBER(),
 }

--- a/src/main/java/com/mate/helgather/exception/ExceptionController.java
+++ b/src/main/java/com/mate/helgather/exception/ExceptionController.java
@@ -1,7 +1,23 @@
 package com.mate.helgather.exception;
 
+import org.apache.catalina.connector.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.net.http.HttpResponse;
+import java.util.NoSuchElementException;
 
 @RestControllerAdvice
 public class ExceptionController {
+    @ExceptionHandler(NoSuchElementException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<BaseResponse> NoMemberException(Exception e) {
+        e.printStackTrace();
+        BaseResponse baseResponse = new BaseResponse(401, "존재하지 않는 유저 입니다.");
+        return new ResponseEntity(baseResponse, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/mate/helgather/repository/MemberRepository.java
+++ b/src/main/java/com/mate/helgather/repository/MemberRepository.java
@@ -4,4 +4,5 @@ import com.mate.helgather.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    boolean existsById(Long id);
 }

--- a/src/main/java/com/mate/helgather/service/ChatRoomService.java
+++ b/src/main/java/com/mate/helgather/service/ChatRoomService.java
@@ -5,6 +5,7 @@ import com.mate.helgather.domain.Message;
 import com.mate.helgather.dto.ChatRoomListResponse;
 import com.mate.helgather.repository.ChatRoomRepository;
 import com.mate.helgather.repository.MemberChatRoomRepository;
+import com.mate.helgather.repository.MemberRepository;
 import com.mate.helgather.repository.MessageRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,31 +14,36 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @AllArgsConstructor
 public class ChatRoomService {
+    private final MemberRepository memberRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final MessageRepository messageRepository;
     private final MemberChatRoomRepository memberChatRoomRepository;
 
-    public List<ChatRoomListResponse> getChatRoomsByMemberId(Long id) {
+    public List<ChatRoomListResponse> getChatRoomsByMemberId(Long id) throws NoSuchElementException {
+        if (!memberRepository.existsById(id)) {
+            throw new NoSuchElementException("존재하지 않는 유저 입니다.");
+        }
         List<MemberChatRoom> memberChatRooms = memberChatRoomRepository.findAllByMemberId(id);
         List<ChatRoomListResponse> chatRoomListResponses = new ArrayList<>();
 
-    for (MemberChatRoom memberChatRoom : memberChatRooms) {
-        Message recentMessage = messageRepository.findTopByChatRoomOrderByCreatedAtDesc(memberChatRoom.getChatRoom())
-                .orElse(Message.builder()
-                        .chatRoom(memberChatRoom.getChatRoom())
-                        .description("아직 채팅이 없습니다.")
-                        .member(null)
-                        .createdAt(LocalDateTime.now())
-                        .build());
-        chatRoomListResponses.add(new ChatRoomListResponse(memberChatRoom.getMember().getNickname(),
-                recentMessage.getCreatedAt().toString(),
-                recentMessage.getDescription(),
-                memberChatRoom.getChatRoom().getId()));
-    }
-    return chatRoomListResponses;
+        for (MemberChatRoom memberChatRoom : memberChatRooms) {
+            Message recentMessage = messageRepository.findTopByChatRoomOrderByCreatedAtDesc(memberChatRoom.getChatRoom())
+                    .orElse(Message.builder()
+                            .chatRoom(memberChatRoom.getChatRoom())
+                            .description("아직 채팅이 없습니다.")
+                            .member(null)
+                            .createdAt(LocalDateTime.now())
+                            .build());
+            chatRoomListResponses.add(new ChatRoomListResponse(memberChatRoom.getMember().getNickname(),
+                    recentMessage.getCreatedAt().toString(),
+                    recentMessage.getDescription(),
+                    memberChatRoom.getChatRoom().getId()));
+        }
+        return chatRoomListResponses;
     }
 }


### PR DESCRIPTION
채팅방 목록을 가져오는 API의 예외를 구현했습니다.
먼저, 간단한 GET 방식이므로, @PathVariable로 넘어오는 유저id에
대해서만 검증을 진행했습니다.