### PR TITLE
채팅 DTO 구분

### DIFF
--- a/src/main/java/com/mate/helgather/controller/ChatController.java
+++ b/src/main/java/com/mate/helgather/controller/ChatController.java
@@ -1,6 +1,8 @@
 package com.mate.helgather.controller;
 
-import com.mate.helgather.dto.ChatDto;
+import com.mate.helgather.domain.Message;
+import com.mate.helgather.dto.ChatRequestDto;
+import com.mate.helgather.dto.ChatResponseDto;
 import com.mate.helgather.dto.MessagesResponse;
 import com.mate.helgather.exception.BaseResponse;
 import com.mate.helgather.service.ChatService;
@@ -11,8 +13,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
-import org.springframework.messaging.simp.annotation.SubscribeMapping;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -24,16 +28,11 @@ public class ChatController {
     private final ChatService chatService;
     private final SimpMessageSendingOperations template;
 
-    @GetMapping("/chat/test")
-    public void testChat() {
-        chatService.testChat();
-    }
-
     @MessageMapping("/chatroom/{id}") // 실제론 메세지 매핑으로 pub/chatroom/{id} 임
-    public void pubMessage(@DestinationVariable("id") Long id, ChatDto chatDTO) throws Exception {
-        log.info("chat {} send by {} to room number{}", chatDTO.getMessage(), chatDTO.getUserId(), id);
-        chatService.saveMessage(chatDTO, id);
-        template.convertAndSend("/sub/chatroom/" + id, chatDTO);
+    public void pubMessage(@DestinationVariable("id") Long chatRoomId, ChatRequestDto chatRequestDTO) throws Exception {
+        log.info("chat {} send by {} to room number{}", chatRequestDTO.getMessage(), chatRequestDTO.getUserId(), chatRoomId);
+        Message message = chatService.saveMessage(chatRequestDTO, chatRoomId);
+        template.convertAndSend("/sub/chatroom/" + chatRoomId, new ChatResponseDto(chatRequestDTO, message));
     }
 
     @GetMapping("/chatroom/{id}")

--- a/src/main/java/com/mate/helgather/dto/ChatRequestDto.java
+++ b/src/main/java/com/mate/helgather/dto/ChatRequestDto.java
@@ -1,0 +1,21 @@
+package com.mate.helgather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class ChatRequestDto {
+    @NotNull(message = "유저 id는 필수 입니다.")
+    private long userId; // 채팅을 보낸 사람
+    @NotNull(message = "메세지는 필수 입니다.")
+    private String message; // 메시지
+    @NotNull(message = "시간은 필수 입니다.")
+    private String time; // 시간은 프론트에서 담아서 보내줄
+    private boolean isFirst;
+    private int userProfile;
+}

--- a/src/main/java/com/mate/helgather/dto/ChatResponseDto.java
+++ b/src/main/java/com/mate/helgather/dto/ChatResponseDto.java
@@ -1,5 +1,6 @@
 package com.mate.helgather.dto;
 
+import com.mate.helgather.domain.Message;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,13 +10,30 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-public class ChatDto {
+public class ChatResponseDto {
     @NotNull(message = "유저 id는 필수 입니다.")
     private long userId; // 채팅을 보낸 사람
+
+    @NotNull(message = "채팅 id는 필수 입니다.")
+    private long chatId; // 채팅 id
+
     @NotNull(message = "메세지는 필수 입니다.")
     private String message; // 메시지
+
     @NotNull(message = "시간은 필수 입니다.")
     private String time; // 시간은 프론트에서 담아서 보내줄
+
     private boolean isFirst;
+
     private int userProfile;
+
+    public ChatResponseDto(ChatRequestDto chatRequestDto, Message message) {
+        this.userId = chatRequestDto.getUserId();
+        this.chatId = message.getId();
+        this.message = chatRequestDto.getMessage();
+        this.time = chatRequestDto.getTime();
+        this.isFirst = chatRequestDto.isFirst();
+        this.userProfile = chatRequestDto.getUserProfile();
+    }
+
 }

--- a/src/main/java/com/mate/helgather/service/ChatService.java
+++ b/src/main/java/com/mate/helgather/service/ChatService.java
@@ -1,21 +1,14 @@
 package com.mate.helgather.service;
 
-import com.mate.helgather.domain.*;
-import com.mate.helgather.domain.status.ChatRoomStatus;
-import com.mate.helgather.domain.status.MemberStatus;
-import com.mate.helgather.domain.status.RecruitmentStatus;
-import com.mate.helgather.dto.ChatDto;
+import com.mate.helgather.domain.Message;
+import com.mate.helgather.dto.ChatRequestDto;
+import com.mate.helgather.dto.MessagesResponse;
 import com.mate.helgather.exception.BaseException;
 import com.mate.helgather.exception.ErrorCode;
-import com.mate.helgather.repository.ChatRoomRepository;
-import com.mate.helgather.repository.MemberRepository;
-import com.mate.helgather.repository.MessageRepository;
+import com.mate.helgather.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import com.mate.helgather.dto.MessagesResponse;
-import com.mate.helgather.repository.*;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -26,13 +19,11 @@ public class ChatService {
     private final ChatRoomRepository chatRoomRepository;
     private final MessageRepository messageRepository;
     private final MemberRepository memberRepository;
-    private final MemberChatRoomRepository memberChatRoomRepository;
-    private final RecruitmentRepository recruitmentRepository;
 
-    public void saveMessage(ChatDto chatDTO, Long chatRoomId) {
-        messageRepository.save(Message.builder().chatRoom(chatRoomRepository.findById(chatRoomId).orElseThrow(NoSuchElementException::new))
-                .member(memberRepository.getReferenceById(chatDTO.getUserId()))
-                .description(chatDTO.getMessage())
+    public Message saveMessage(ChatRequestDto chatRequestDTO, Long chatRoomId) {
+        return messageRepository.save(Message.builder().chatRoom(chatRoomRepository.findById(chatRoomId).orElseThrow(NoSuchElementException::new))
+                .member(memberRepository.getReferenceById(chatRequestDTO.getUserId()))
+                .description(chatRequestDTO.getMessage())
                 .build());
     }
 
@@ -52,51 +43,5 @@ public class ChatService {
         }
 
         return messagesResponses;
-    }
-
-    public void testChat() {
-        Member member1 = Member.builder()
-                .userName("김지홍")
-                .nickname("jihonkim")
-                .password("11")
-                .phone("01085422990")
-                .birthDate(LocalDate.of(1998, 03, 31))
-                .status(MemberStatus.ACTIVE)
-                .build();
-        Member member2 = Member.builder()
-                .userName("노균욱")
-                .nickname("gyroh")
-                .password("11")
-                .phone("0109991290")
-                .birthDate(LocalDate.of(1997, 04, 13))
-                .status(MemberStatus.ACTIVE)
-                .build();
-        memberRepository.save(member1);
-        memberRepository.save(member2);
-
-        Recruitment recruitment = Recruitment.builder()
-                .member(member1)
-                .title("3대 500 운동파트너 구합니다")
-                .description("ㅈㄱㄴ")
-                .status(RecruitmentStatus.ACTIVE)
-                .build();
-        recruitmentRepository.save(recruitment);
-
-        ChatRoom chatRoom = ChatRoom.builder()
-                .recruitment(recruitment)
-                .status(ChatRoomStatus.ACTIVE)
-                .build();
-        chatRoomRepository.save(chatRoom);
-
-        MemberChatRoom memberChatRoom1 = MemberChatRoom.builder()
-                .chatRoom(chatRoom)
-                .member(member1)
-                .build();
-        MemberChatRoom memberChatRoom2 = MemberChatRoom.builder()
-                .chatRoom(chatRoom)
-                .member(member2)
-                .build();
-        memberChatRoomRepository.save(memberChatRoom1);
-        memberChatRoomRepository.save(memberChatRoom2);
     }
 }


### PR DESCRIPTION
# 변경 전
- ChatDto

# 변경 후
- ChatRequestDto
- ChatResponseDto

이렇게 변경한 이유는 프론트 엔드에서 채팅의 고유한 id값이 필요했기 때문입니다.
따라서 발행할 때는 id가 없는 ChatRequestDto로 받지만, DB에 저장하고 나서 보내줄 때는 고유한 채팅 id를 담은 ChatResponseDto를 발행합니다.