### PR TITLE
Spring REST Docs 적용 완료 및 profiles 세분화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// jasypt 암호화
+	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+
 	// mockmvc
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.10'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
-	id "org.asciidoctor.convert" version "1.5.9.2" // 아스키 독 플러그인
+	id "org.asciidoctor.jvm.convert" version "3.3.2" // 아스키 독 플러그인
 }
 
 group = 'com.mate'
@@ -10,6 +10,7 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {
+	asciidoctorExtensions
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
@@ -61,7 +62,8 @@ dependencies {
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
 
-	asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+	// Spring Rest Docs에서 mockMvc를 사용해 스니펫 조각들을 뽑아낸다는 의미.
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
 	compileOnly 'org.projectlombok:lombok'
@@ -69,6 +71,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 
 	annotationProcessor 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok' // Spring Rest Docs로 인한 추가
 }
 
 ext {
@@ -76,18 +79,36 @@ ext {
 }
 
 test {
-	useJUnitPlatform()
+	// 테스트의 아웃풋이 위에서 설정한 스니펫 디렉토리로 출력(저장)된다.
 	outputs.dir snippetsDir
+	useJUnitPlatform()
 }
 
 asciidoctor {
-	inputs.dir snippetsDir
-	dependsOn test
+	dependsOn test // 테스트 이후 작동 설정
+	configurations 'asciidoctorExtensions' // 위 설정한 configuration 적용
+	inputs.dir snippetsDir // snippetsDir를 입력으로
+
+	baseDirFollowsSourceFile() // 특정 파일 인클루드 시, 경로를 베이스 디렉토리로 맞춰줌.
 }
 
-bootJar {
-	dependsOn asciidoctor
-	from ("${asciidoctor.outputDir}/html5") {
-		into 'static/docs'
-	}
+asciidoctor.doFirst {
+	delete file('src/main/resources/static/docs')
 }
+
+task copyDocument(type: Copy) {
+	dependsOn asciidoctor
+	from file("build/docs/asciidoc")
+	into file("src/main/resources/static/docs")
+}
+
+build {
+	dependsOn copyDocument
+}
+//copyDocument
+//bootJar {
+//	dependsOn asciidoctor
+//	from ("${asciidoctor.outputDir}/html5") {
+//		into 'static/docs'
+//	}
+//}

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,42 @@
+= Hel-gather API 명세
+:doctype: book
+:icons: font
+// 문서에 표기되는 코드들 하이라이트
+:source-highlighter: prettify
+// 컨텐츠를 왼쪽에 두겠다는 의미
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+[[모집]]
+== 모집 API
+[[모집-게시글-API]]
+=== 모집 생성 API
+operation::게시물 생성 API[snippets='http-request,request-parameters,request-parts,http-response,response-fields']
+
+[[모집-ID-조회-API]]
+=== 모집 ID 조회 API
+operation::게시물 ID 조회 API[snippets='http-request,request-parameters,request-parts,http-response,response-fields']
+
+[[모집-전체조회-API]]
+=== 모집 전체 조회 API
+operation::게시물 전체 조회 API[snippets='http-request,request-parameters,request-parts,http-response,response-fields']
+
+[[모집-필터링-조회-API]]
+=== 모집 필터링 조회 API
+operation::게시물 필터링 조회 API[snippets='http-request,request-parameters,request-parts,http-response,response-fields']
+
+
+[[운동]]
+== 운동 API
+[[운동-인증-API]]
+=== 운동 인증 API
+operation::exercise_post_API[snippets='http-request,request-parameters,request-parts,http-response,response-fields']
+
+[[운동-삭제-API]]
+=== 운동 삭제 API
+operation::운동 게시물 삭제 API[snippets='http-request,request-parameters,request-parts,http-response,response-fields']
+
+[[운동-게시물-전체조회-API]]
+=== 운동 게시물 전체조회 API
+operation::운동 게시물 전체조회 API[snippets='http-request,request-parameters,request-parts,http-response,response-fields']

--- a/src/main/java/com/mate/helgather/HelGatherApplication.java
+++ b/src/main/java/com/mate/helgather/HelGatherApplication.java
@@ -2,10 +2,9 @@ package com.mate.helgather;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@SpringBootApplication
 @EnableJpaAuditing
 public class HelGatherApplication {
 	static {

--- a/src/main/java/com/mate/helgather/configuration/JasyptConfig.java
+++ b/src/main/java/com/mate/helgather/configuration/JasyptConfig.java
@@ -1,0 +1,31 @@
+package com.mate.helgather.configuration;
+
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableEncryptableProperties
+public class JasyptConfig {
+
+    @Bean("jasyptEncryptorAES")
+    public StringEncryptor stringEncryptor() {
+        String key = "helgather-secret";
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+
+        config.setPassword(key); // 암호화키
+        config.setAlgorithm("PBEWITHHMACSHA512ANDAES_256"); // 알고리즘
+        config.setKeyObtentionIterations("1000"); // 반복할 해싱 회수
+        config.setPoolSize("1"); // 인스턴스 pool
+        config.setProviderName("SunJCE");
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator"); // salt 생성 클래스
+        config.setIvGeneratorClassName("org.jasypt.iv.RandomIvGenerator");
+        config.setStringOutputType("base64"); //인코딩 방식
+        encryptor.setConfig(config);
+        return encryptor;
+    }
+}

--- a/src/main/java/com/mate/helgather/controller/ExerciseController.java
+++ b/src/main/java/com/mate/helgather/controller/ExerciseController.java
@@ -5,6 +5,7 @@ import com.mate.helgather.dto.TodayExerciseResponseDto;
 import com.mate.helgather.exception.BaseResponse;
 import com.mate.helgather.service.ExerciseService;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,27 +15,29 @@ import java.util.List;
 
 @RestController
 @AllArgsConstructor
+@Slf4j
+@RequestMapping("/exercises")
 public class ExerciseController {
     private final ExerciseService exerciseService;
 
-    @GetMapping("/exercises")
+    @GetMapping
     public ResponseEntity<BaseResponse> findAllByMemberId(@RequestParam("member") Long memberId) {
-        //TODO: memberId 1에서 오류 발생
         List<TodayExerciseResponseDto> todayExerciseResponseDtos = exerciseService.findAllByMemberId(memberId);
         return new ResponseEntity<>(new BaseResponse(todayExerciseResponseDtos), HttpStatus.OK);
     }
 
-    @PostMapping("/exercises")
-    public ResponseEntity<BaseResponse> save(@RequestParam("member") Long memberId,
-                                                          @RequestPart("file") MultipartFile multipartFile) {
+    @PostMapping
+    public ResponseEntity<BaseResponse> create(@RequestParam("member") Long memberId,
+                                               @RequestPart("file") MultipartFile multipartFile) {
         TodayExerciseResponseDto todayExerciseResponseDto = exerciseService.save(memberId, multipartFile);
         return new ResponseEntity<>(new BaseResponse(todayExerciseResponseDto), HttpStatus.OK);
     }
 
-    @DeleteMapping("/exercises")
-    public ResponseEntity<BaseResponse> delete(@PathVariable("member") Long memberId,
-                                                         TodayExerciseRequestDto todayExerciseRequestDto) throws Exception {
-        exerciseService.delete(memberId, todayExerciseRequestDto);
+    @DeleteMapping
+    public ResponseEntity<BaseResponse> delete(@RequestParam("member") Long memberId,
+                                               @RequestParam("imageUrl") String imageUrl) {
+        //TODO: 임시 개편
+        exerciseService.delete(memberId, new TodayExerciseRequestDto(imageUrl));
         return new ResponseEntity<>(new BaseResponse("삭제 성공"), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/mate/helgather/controller/RecruitmentController.java
+++ b/src/main/java/com/mate/helgather/controller/RecruitmentController.java
@@ -53,7 +53,7 @@ public class RecruitmentController {
     @GetMapping("/all")
     public ResponseEntity<BaseResponse> findAll() {
         List<RecruitmentListResponseDto> recruitmentListResponseDtos = recruitmentService.findAll();
-
+        System.out.println("in ct hash : " + recruitmentListResponseDtos);
         return new ResponseEntity<>(new BaseResponse(recruitmentListResponseDtos), HttpStatus.OK);
     }
 
@@ -111,8 +111,10 @@ public class RecruitmentController {
         if (bindingResult.hasErrors()) {
             throw new BaseException(ErrorCode.FORMAT_ERROR);
         }
+        System.out.println("in ct : " + recruitmentOptions);
         //TODO: 조건이 일부 없어도 동작되게 만들고 싶은데 방법 찾아볼 것.
         List<RecruitmentListResponseDto> recruitmentListResponseDtos = recruitmentService.findByOptions(recruitmentOptions);
+//        System.out.println("in ct hash = " + recruitmentListResponseDtos);
         return new ResponseEntity<>(new BaseResponse(recruitmentListResponseDtos), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/mate/helgather/controller/ServerController.java
+++ b/src/main/java/com/mate/helgather/controller/ServerController.java
@@ -1,0 +1,30 @@
+package com.mate.helgather.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@PropertySource(value = "application.yml")
+public class ServerController {
+
+    @Value("${serverName}")
+    private String serverName;
+    private Integer visitedCount = 0;
+
+    @GetMapping("/getServerInfo")
+    public ResponseEntity<Map<String, String>> getServerInfo(){
+        visitedCount++;
+
+        Map<String, String> serverInfo = new HashMap<>();
+        serverInfo.put("ServerName:", serverName);
+        serverInfo.put("visitedCount:", visitedCount.toString());
+
+        return ResponseEntity.ok(serverInfo);
+    }
+}

--- a/src/main/java/com/mate/helgather/dto/TodayExerciseRequestDto.java
+++ b/src/main/java/com/mate/helgather/dto/TodayExerciseRequestDto.java
@@ -1,10 +1,14 @@
 package com.mate.helgather.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@RequiredArgsConstructor
+@Data
 public class TodayExerciseRequestDto {
     private String imageUrl;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,10 +2,9 @@ spring:
   profile:
     group:
       local: common, local-db
-      prod: common, prod-db
-
-server:
-  port: 8080
+      prod1: common, prod-db, prod1
+      prod2: common, prod-db, prod2
+      prod3: common, prod-db, prod3
 
 jwt:
   secret: VlwEyVBsYt9V7zq57TejMnVUyzblYcfPQye08f7MGVA9XkHa
@@ -19,8 +18,8 @@ cloud:
     s3:
       bucket: hel-gather-s3
     credentials:
-      access-key: ENC(M4edAaknqmrwM/Y3Jld99CTyBHMur5fUb8T0Qqr/G3XHjBNx0KSZdlKaZHKc+po/M6JTqKMxbbmnXZ8RbKpy2w==)
-      secret-key: ENC(BufWatmfEgFIiGdqGEz726vCmDwoW2O5x66wTsOVr4WimODufIFbsRVZi+pw/wMfkwi5Dck3YDp35+VUeIRvs1F1G7L08YDmTJoP53+fBnw=)
+      access-key: ENC(X6mP91P3GtjXmsn1HRqSUR1jzPzi/F4/6sJKc9YyYfh7sSVhSnQOpwijUAnvlC60RI5gEVOd5nFLwzK/X0jgig==)
+      secret-key: ENC(K3UNLT8RnQLkQ1ACC9YTCb6syCkVDg91U8RQHVieqG04j9Npw55Ixm5xvWCQh3a+cUvqbxcoyRwi6jbWmS7rReSp7KqmQkFWwRv00Su8ZJY=)
     region:
       static: ap-northeast-2
       auto: false
@@ -66,9 +65,9 @@ spring:
     activate:
       on-profile: prod-db
   datasource:
-    url: ENC(J207p+aaszvNyuANu3K9GJ5HwvqG553wp4sPUO2bXeNkEDE3iHQZTFqBXc/6he2eKHyhV5ivDXFGWbdgOKymhF9AY6rjjc0vVF4+2p8ARWRQ4cBfT6WVMKaQryfmILpBglZdARoInRynr+w2PYYxKgS/YcLiRePOgcDYwli4V3SfkeOxYHkmITen0xyTTmLg6/OsVwEHZwxLA8yt9FidIyB4DRZEoLknm20lVFREZnh8PlV6AnCeetyFCOXBCVtc)
-    username: ENC(oQ6VBevtOVq9lt3vjoI/NbfwwkZXNUuNBTtir4J6JlFtmqkP8DQySIWPbDIVd4lR)
-    password: ENC(z7q+OQd9nPPHmUxBcAPv68dYO2w3Gz32Y24b0mz7Q4kbtQajUTo5eNLYyY5Ymv+/)
+    url: ENC(4h35jdBKUxNmd3F9HqNzPmKMI1FQfknTbRK/9R25bOvSG7tUgYd7UxCCrZuUSrJBmrauBQpjdZGjZY91QHP5U/GsZm0HG1xUXcPT/UHd0UJuQjr2nkLOajdZAydlonhUbdxgt3R17wTtudlrbhjaUT3KDrLZkthitdpDBSilUjcl3GH7K6XUKbXxCpC9T6+sqcRi/iVxjRUkaCN7a1nG+FcHjN2LBDdhLRP2fmyvpkIW50Tcb4jwrJIlISpPgZrmDvsT+9H2wiS9q78aTQzMcg==)
+    username: ENC(IoypxQU/L2gWg4z/XTbzmSNVTelD0HfRhmpOYSgxy/jQcK+EeJPEUVFnq6wVK4Mp)
+    password: ENC(7qwkjtEPdsPqgic+P3btJSd9i6qUldsDKPE6pmyHuxb1ipr5wtu/o8J93hs4MaZS)
   #    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
@@ -78,3 +77,50 @@ spring:
         format_sql: true
         show_sql: true
 
+---
+
+spring:
+  config:
+    activate:
+      on-profile: prod1
+
+serverName: hel-gather-prod1
+
+server:
+  port: 8080
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: prod2
+
+serverName: hel-gather-prod2
+
+server:
+  port: 8081
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: prod3
+
+serverName: hel-gather-prod3
+
+server:
+  port: 8080
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: prod4
+
+serverName: hel-gather-prod4
+
+server:
+  port: 8081

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,29 @@ spring:
       local: common, local-db
       prod: common, prod-db
 
+server:
+  port: 8080
+
+jwt:
+  secret: VlwEyVBsYt9V7zq57TejMnVUyzblYcfPQye08f7MGVA9XkHa
+
+jasypt:
+  encryptor:
+    bean: jasyptEncryptorAES
+
+cloud:
+  aws:
+    s3:
+      bucket: hel-gather-s3
+    credentials:
+      access-key: ENC(M4edAaknqmrwM/Y3Jld99CTyBHMur5fUb8T0Qqr/G3XHjBNx0KSZdlKaZHKc+po/M6JTqKMxbbmnXZ8RbKpy2w==)
+      secret-key: ENC(BufWatmfEgFIiGdqGEz726vCmDwoW2O5x66wTsOVr4WimODufIFbsRVZi+pw/wMfkwi5Dck3YDp35+VUeIRvs1F1G7L08YDmTJoP53+fBnw=)
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false
+
 ---
 
 spring:
@@ -17,30 +40,11 @@ spring:
   application:
     name: helgather
 
-  cloud:
-    aws:
-      s3:
-        bucket: hel-gather-s3
-      credentials:
-        access-key: AKIA5IZYF7FRFZEO3WT3
-        secret-key: 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
-      region:
-        static: ap-northeast-2
-        auto: false
-      stack:
-        auto: false
-
-  server:
-    port: 8080
-
-  jwt:
-    secret: VlwEyVBsYt9V7zq57TejMnVUyzblYcfPQye08f7MGVA9XkHa
-
 ---
 
 spring:
   config:
-    active:
+    activate:
       on-profile: local-db
   datasource:
     url: jdbc:h2:tcp://localhost/~/helgather
@@ -59,12 +63,12 @@ spring:
 
 spring:
   config:
-    active:
+    activate:
       on-profile: prod-db
   datasource:
-    url: jdbc:mysql://hel-gather-prod-db-instance-1.cdvy1x08ijsd.ap-northeast-2.rds.amazonaws.com:3306/hel_gather_prod?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: kingjihong
-    password: aA1349529!!!!
+    url: ENC(J207p+aaszvNyuANu3K9GJ5HwvqG553wp4sPUO2bXeNkEDE3iHQZTFqBXc/6he2eKHyhV5ivDXFGWbdgOKymhF9AY6rjjc0vVF4+2p8ARWRQ4cBfT6WVMKaQryfmILpBglZdARoInRynr+w2PYYxKgS/YcLiRePOgcDYwli4V3SfkeOxYHkmITen0xyTTmLg6/OsVwEHZwxLA8yt9FidIyB4DRZEoLknm20lVFREZnh8PlV6AnCeetyFCOXBCVtc)
+    username: ENC(oQ6VBevtOVq9lt3vjoI/NbfwwkZXNUuNBTtir4J6JlFtmqkP8DQySIWPbDIVd4lR)
+    password: ENC(z7q+OQd9nPPHmUxBcAPv68dYO2w3Gz32Y24b0mz7Q4kbtQajUTo5eNLYyY5Ymv+/)
   #    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,15 @@
-server:
-  port: 8080
+spring:
+  profile:
+    group:
+      local: common, local-db
+      prod: common, prod-db
+
+---
 
 spring:
+  config:
+    activate:
+      on-profile: common
   servlet:
     multipart:
       max-file-size: 20MB
@@ -9,6 +17,31 @@ spring:
   application:
     name: helgather
 
+  cloud:
+    aws:
+      s3:
+        bucket: hel-gather-s3
+      credentials:
+        access-key: AKIA5IZYF7FRFZEO3WT3
+        secret-key: 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
+      region:
+        static: ap-northeast-2
+        auto: false
+      stack:
+        auto: false
+
+  server:
+    port: 8080
+
+  jwt:
+    secret: VlwEyVBsYt9V7zq57TejMnVUyzblYcfPQye08f7MGVA9XkHa
+
+---
+
+spring:
+  config:
+    active:
+      on-profile: local-db
   datasource:
     url: jdbc:h2:tcp://localhost/~/helgather
     username: kingjihong
@@ -21,19 +54,23 @@ spring:
       hibernate:
         format_sql: true
         show_sql: true
-cloud:
-  aws:
-    s3:
-      bucket: hel-gather
-    credentials:
-      access-key: AKIATNMKTXLNOOG6SY7F
-      secret-key: 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
-    region:
-      static: ap-northeast-2
-      auto: false
-    stack:
-      auto: false
 
-jwt:
-  secret: VlwEyVBsYt9V7zq57TejMnVUyzblYcfPQye08f7MGVA9XkHa
+---
+
+spring:
+  config:
+    active:
+      on-profile: prod-db
+  datasource:
+    url: jdbc:mysql://hel-gather-prod-db-instance-1.cdvy1x08ijsd.ap-northeast-2.rds.amazonaws.com:3306/hel_gather_prod?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: kingjihong
+    password: aA1349529!!!!
+  #    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
 

--- a/src/test/java/com/mate/helgather/controller/ExerciseControllerTest.java
+++ b/src/test/java/com/mate/helgather/controller/ExerciseControllerTest.java
@@ -1,0 +1,154 @@
+package com.mate.helgather.controller;
+
+import com.mate.helgather.dto.TodayExerciseResponseDto;
+import com.mate.helgather.service.ExerciseService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc // -> webAppContextSetup(webApplicationContext)
+@AutoConfigureRestDocs // -> apply(documentationConfiguration(restDocumentation))
+@WebMvcTest(ExerciseController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+class ExerciseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ExerciseService exerciseService;
+
+    private String token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjb3JlTmljazciLCJhdXRoIjoiUk9MRV9VU0VSIiwiZXhwIjoxNjg4NDcyMzA3fQ.bBWrIpULfrZsIUAF-MrhPa100k-b0d6LF84Iyr-Gjss";
+    private String imageUrl1 = "https://s3.bucket.image3.com";
+    private String httpImageUrl1 = "http://s3.bucket.image3.com";
+    private String imageUrl2 = "https://s3.bucket.image2.com";
+    private String imageUrl3 = "https://s3.bucket.image1.com";
+
+    @Test
+    @DisplayName("운동 인증 테스트")
+    @WithMockUser(username = "김씨")
+        // 오류사항1
+    void create() throws Exception {
+        MockMultipartFile multipartFile = new MockMultipartFile("file", "file".getBytes(StandardCharsets.UTF_8));
+
+        when(exerciseService.save(anyLong(), any(MockMultipartFile.class)))
+                .thenReturn(new TodayExerciseResponseDto(imageUrl1));
+
+        this.mockMvc.perform(RestDocumentationRequestBuilders.multipart("/exercises")
+                        .file(multipartFile)
+                        .header("Authorization", "Bearer " + token)
+                        .queryParam("member", "1")
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .with(csrf())) // 오류사항2
+                .andExpect(status().isOk())
+                .andDo(document("exercise_post_API",
+                        requestParameters(
+                                parameterWithName("member").description("멤버 id"),
+                                parameterWithName("_csrf").description("csrf").ignored() // requestParam 사용시 에러처리
+                        ),
+                        requestParts(
+                                partWithName("file").description("동영상 파일")
+                        ),
+                        responseFields(
+                                fieldWithPath("isSuccess").description("성공여부"),
+                                fieldWithPath("code").description("코드"),
+                                fieldWithPath("message").description("설명"),
+                                fieldWithPath("result").description("결과"),
+                                fieldWithPath("result.imageUrl").description("이미지 URL")
+                        )
+
+                ));
+    }
+
+    @Test
+    @DisplayName("게시글 id 조회 테스트")
+    @WithMockUser(username = "김씨")
+        // 오류사항1
+    void findAllByMemberId() throws Exception {
+        // given
+        List<TodayExerciseResponseDto> todayExerciseResponseDtos = new ArrayList<>();
+        todayExerciseResponseDtos.add(new TodayExerciseResponseDto(imageUrl1));
+        todayExerciseResponseDtos.add(new TodayExerciseResponseDto(imageUrl2));
+        todayExerciseResponseDtos.add(new TodayExerciseResponseDto(imageUrl3));
+
+        //when
+        when(exerciseService.findAllByMemberId(anyLong())).thenReturn(todayExerciseResponseDtos);
+
+        this.mockMvc.perform(get("/exercises")
+                        .header("Authorization", "Bearer " + token)
+                        .queryParam("member", "1")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf())) // 오류사항2
+
+                // then
+                .andExpect(status().isOk())
+                .andDo(document("운동 게시물 전체조회 API",
+                        requestParameters(
+                                parameterWithName("member").description("멤버 id"),
+                                parameterWithName("_csrf").description("csrf").ignored() // requestParam 사용시 에러처리
+                        ),
+                        responseFields(
+                                fieldWithPath("isSuccess").description("성공여부"),
+                                fieldWithPath("code").description("코드"),
+                                fieldWithPath("message").description("설명"),
+                                fieldWithPath("result").description("결과"),
+                                fieldWithPath("result[].imageUrl").description("이미지 URL")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("게시글 id 조회 테스트")
+    @WithMockUser(username = "김씨")
+    void deleteV1() throws Exception {
+        // given
+        // when
+
+        this.mockMvc.perform(delete("/exercises")
+                        .header("Authorization", "Bearer " + token)
+                        .queryParam("member", "1")
+                        .queryParam("imageUrl", "http://sff.sl")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf())) // 오류사항2
+                // then
+                .andExpect(status().isOk())
+                .andDo(document("운동 게시물 삭제 API",
+                        requestParameters(
+                                parameterWithName("member").description("멤버 id"),
+                                parameterWithName("imageUrl").description("삭제할 이미지 URL(HTTP)"),
+                                parameterWithName("_csrf").description("csrf").ignored() // requestParam 사용시 에러처리
+                        ),
+                        responseFields(
+                                fieldWithPath("isSuccess").description("성공여부"),
+                                fieldWithPath("code").description("코드"),
+                                fieldWithPath("message").description("설명"),
+                                fieldWithPath("result").description("결과")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/mate/helgather/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/mate/helgather/controller/RecruitmentControllerTest.java
@@ -17,15 +17,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.LocalDate;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -48,9 +47,6 @@ class RecruitmentControllerTest {
 
     @MockBean
     private RecruitmentService recruitmentService;
-
-//    @Autowired
-//    private ApplicationContext applicationContext;
 
     private String token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjb3JlTmljazciLCJhdXRoIjoiUk9MRV9VU0VSIiwiZXhwIjoxNjg4NDcyMzA3fQ.bBWrIpULfrZsIUAF-MrhPa100k-b0d6LF84Iyr-Gjss";
 
@@ -155,6 +151,7 @@ class RecruitmentControllerTest {
                     .description("3~6시 아무때나 연락주세요!!")
                     .status(RecruitmentStatus.ACTIVE)
                     .build()));
+        System.out.println("in tc : " + recruitmentResponseDtos);
         //when
         when(recruitmentService.findAll()).thenReturn(recruitmentResponseDtos);
 
@@ -178,18 +175,6 @@ class RecruitmentControllerTest {
                                 fieldWithPath("result[].createdAt").description("작성일")
                         )
                 ));
-        MvcResult mvcResult = resultActions.andReturn();
-        MockHttpServletResponse response = mvcResult.getResponse();
-
-// 출력
-        System.out.println("Status = " + response.getStatus());
-        System.out.println("Error message = " + response.getErrorMessage());
-        System.out.println("Headers = " + response.getHeaderNames());
-        System.out.println("Content type = " + response.getContentType());
-        System.out.println("Body = " + response.getContentAsString());
-        System.out.println("Forwarded URL = " + response.getForwardedUrl());
-        System.out.println("Redirected URL = " + response.getRedirectedUrl());
-        System.out.println("Cookies = " + response.getCookies());
     }
 
     @Test
@@ -204,11 +189,10 @@ class RecruitmentControllerTest {
                 .birthDate(LocalDate.of(2004, 5, 31))
                 .password("kksf")
                 .build();
-
         final List<RecruitmentListResponseDto> recruitmentResponseDtos = List.of(new RecruitmentListResponseDto(Recruitment.builder()
                         .id(1L)
                         .member(member)
-                        .subLocation(2L)
+                        .subLocation(1L)
                         .location(2L)
                         .title("같이 운동하실분")
                         .description("내일쯤 예상하고 있습니다.")
@@ -223,17 +207,16 @@ class RecruitmentControllerTest {
                         .description("3~6시 아무때나 연락주세요!!")
                         .status(RecruitmentStatus.ACTIVE)
                         .build()));
-        RecruitmentOptions recruitmentOptions = new RecruitmentOptions(2L, 2L, 80,
-                100, 30, 80, 80, 100);
+        RecruitmentOptions recruitmentOptions = new RecruitmentOptions(2L, 1L, 80,
+                100, 80, 120, 80, 110);
         //when
-        when(recruitmentService.findByOptions(recruitmentOptions)).thenReturn(recruitmentResponseDtos);
-
-      this.mockMvc.perform(get("/recruitments")
+        when(recruitmentService.findByOptions(any())).thenReturn(recruitmentResponseDtos);
+        this.mockMvc.perform(get("/recruitments")
                 .header("Authorization", "Bearer " + token)
                 .accept(MediaType.APPLICATION_JSON)
                 .with(csrf()) // 오류사항2
                 .queryParam("location", "2")
-                .queryParam("subLocation", "2")
+                .queryParam("subLocation", "1")
                 .queryParam("maxDeadLift", "100")
                 .queryParam("minDeadLift", "80")
                 .queryParam("maxSquat", "120")
@@ -241,19 +224,6 @@ class RecruitmentControllerTest {
                 .queryParam("maxBenchPress", "110")
                 .queryParam("minBenchPress", "90"))
                 .andExpect(status().isOk())
-
-//        MvcResult mvcResult = resultActions.andReturn();
-//        MockHttpServletResponse response = mvcResult.getResponse();
-
-// 출력
-//        System.out.println("Status = " + response.getStatus());
-//        System.out.println("Error message = " + response.getErrorMessage());
-//        System.out.println("Headers = " + response.getHeaderNames());
-//        System.out.println("Content type = " + response.getContentType());
-//        System.out.println("Body = " + response.getContentAsString());
-//        System.out.println("Forwarded URL = " + response.getForwardedUrl());
-//        System.out.println("Redirected URL = " + response.getRedirectedUrl());
-//        System.out.println("Cookies = " + response.getCookies());
 
                 .andDo(document("게시물 필터링 조회 API",
                         requestParameters(


### PR DESCRIPTION
# 변경사항
## Spring REST Docs 적용
신뢰성 있는 API 명세를 위한 Spring REST Docs를 적용했습니다.
띄워진 서버에 /docs/index.html을 통해 확인할 수 있습니다.
자세한 사항은 블로그 [적용기](https://velog.io/@soluinoon/Spring-Rest-Docs-%EC%A0%81%EC%9A%A9%EA%B8%B0)를 확인해주세요.

## profiles 세분화
로컬, 배포 서버에서 db설정과 포트설정을 다르게 적용하기 위해 profiles를 세분화 했습니다.
적용 역시 블로그 글을 참고해주세요!